### PR TITLE
script: Fix build and link errors when running test-plsan.sh

### DIFF
--- a/RuntimeLibrary/plsan_handler.cpp
+++ b/RuntimeLibrary/plsan_handler.cpp
@@ -1,4 +1,5 @@
 #include "plsan_handler.h"
+#include <cstdlib>
 
 namespace __plsan {
 
@@ -6,6 +7,8 @@ void PlsanHandler::exception_check(RefCountAnalysis ref_count_analysis) {
   AddrType addrType;
   ExceptionType exceptionType;
   std::tie(addrType, exceptionType) = ref_count_analysis;
+  print_stack_trace(NULL, 0, std::cerr);
+  exit(EXIT_FAILURE);
 }
 
 } // namespace __plsan


### PR DESCRIPTION
Linking objects need to be done using clang++ because runtime library is written in C++. Therefore separate build and link process in the script.