### PR TITLE
Change STL to sanitizer common library

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -81,7 +81,7 @@ extern "C" void __plsan_lazy_check(LazyCheckInfo *lazy_check_info,
   void *program_counter = lazy_check_info->ProgramCounterAddr;
 
   for (int i = 0; i < lazy_check_addr_list->Size(); i++) {
-    if (&lazy_check_addr_list[i] != ret_addr)
+    if ((*lazy_check_addr_list)[i] != ret_addr)
       throw ret_addr;
   }
 

--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -1,4 +1,5 @@
 #include "plsan.h"
+#include "sanitizer_common/sanitizer_libc.h"
 
 #include <cstdarg>
 #include <cstddef>
@@ -7,8 +8,13 @@
 __plsan::Plsan *plsan;
 
 namespace {
-using LazyCheckInfo = std::tuple</*RefCountZeroAddrs=*/std::vector<void *> *,
-                                 /*ProgramCounterAddr=*/void *>;
+struct LazyCheckInfo {
+  __sanitizer::Vector<void *> *RefCountZeroAddrs;
+  void *ProgramCounterAddr;
+};
+// using LazyCheckInfo =
+// std::tuple</*RefCountZeroAddrs=*/__sanitizer::Vector<void *> *,
+//                                  /*ProgramCounterAddr=*/void *>;
 }
 
 /* Initialization routines called before main() */
@@ -31,47 +37,54 @@ extern "C" void __plsan_store(void **lhs, void *rhs) {
   plsan->reference_count(lhs, rhs);
 }
 
-extern "C" std::tuple<std::vector<void *> *, void *> *
+extern "C" LazyCheckInfo *
 __plsan_free_stack_variables(size_t count, void *ret_addr, int is_return, ...) {
   // We cannot use C++ style variable arguments, because extern keyword for
   // compatiable with C.
 
-  std::vector<void **> args;
+  __sanitizer::Vector<void **> args;
 
   va_list var_addrs;
   va_start(var_addrs, is_return);
 
   for (int i = 0; i < count; i++)
-    args.push_back(va_arg(var_addrs, void **));
+    args.PushBack(va_arg(var_addrs, void **));
 
   va_end(var_addrs);
 
-  std::vector<void *> *ref_count_zero_addrs =
+  __sanitizer::Vector<void *> *ref_count_zero_addrs =
       plsan->free_stack_variables(ret_addr, is_return, args);
 
   // This return will be changed. It have to contain stack trace data.
   // __builtin_return_address(0) will return program counter
-  return new std::tuple(ref_count_zero_addrs, __builtin_return_address(0));
+  LazyCheckInfo *LCI = new LazyCheckInfo();
+  LCI->RefCountZeroAddrs = ref_count_zero_addrs;
+  LCI->ProgramCounterAddr = __builtin_return_address(0);
+  return LCI;
 }
 
-extern "C" std::tuple<std::vector<void *> *, void *> *
-__plsan_free_stack_array(void **arr_start_addr, size_t size, void *ret_addr,
-                         bool is_return) {
-  std::vector<void *> *ref_count_zero_addrs =
+extern "C" LazyCheckInfo *__plsan_free_stack_array(void **arr_start_addr,
+                                                   size_t size, void *ret_addr,
+                                                   bool is_return) {
+  __sanitizer::Vector<void *> *ref_count_zero_addrs =
       plsan->free_stack_array(arr_start_addr, size, ret_addr, is_return);
 
   // This return will be changed. It have to contain stack trace data.
   // __builtin_return_address(0) will return program counter
-  return new std::tuple(ref_count_zero_addrs, __builtin_return_address(0));
+  LazyCheckInfo *LCI = new LazyCheckInfo();
+  LCI->RefCountZeroAddrs = ref_count_zero_addrs;
+  LCI->ProgramCounterAddr = __builtin_return_address(0);
+  return LCI;
 }
 
 extern "C" void __plsan_lazy_check(LazyCheckInfo *lazy_check_info,
                                    void *ret_addr) {
-  std::vector<void *> *lazy_check_addr_list = std::get<0>(*lazy_check_info);
-  void *program_counter = std::get<1>(*lazy_check_info);
+  __sanitizer::Vector<void *> *lazy_check_addr_list =
+      lazy_check_info->RefCountZeroAddrs;
+  void *program_counter = lazy_check_info->ProgramCounterAddr;
 
-  for (void *lazy_check_addr : *lazy_check_addr_list) {
-    if (lazy_check_addr != ret_addr)
+  for (int i = 0; i < lazy_check_addr_list->Size(); i++) {
+    if (&lazy_check_addr_list[i] != ret_addr)
       throw ret_addr;
   }
 
@@ -119,7 +132,7 @@ void Plsan::init_refcnt(void *addr, size_t size) {
   // https://github.com/hygoni/precise-leak-sanitizer/issues/29
 
   int8_t initialize_value = '\0';
-  memset(addr, initialize_value, size);
+  __sanitizer::__sanitizer_internal_memset(addr, initialize_value, size);
 
   shadow->alloc_shadow(addr, size);
 }
@@ -136,9 +149,9 @@ void Plsan::reference_count(void **lhs, void *rhs) {
   check_memory_leak(*lhs);
 }
 
-std::vector<void *> *
+__sanitizer::Vector<void *> *
 Plsan::free_stack_variables(void *ret_addr, bool is_return,
-                            std::vector<void **> var_addrs) {
+                            __sanitizer::Vector<void **> &var_addrs) {
   // free_stack_variables method calls above return instruction or some method
   // that pop(restore) stack.
   // 1. If free_stack_variables calls above return instruction, then "is_return"
@@ -153,14 +166,16 @@ Plsan::free_stack_variables(void *ret_addr, bool is_return,
   // If is_return is falsem, then this method return target address that check
   // leak lazily.
 
-  std::vector<void *> *ref_count_zero_addrs = new std::vector<void *>();
+  __sanitizer::Vector<void *> *ref_count_zero_addrs =
+      new __sanitizer::Vector<void *>();
 
-  for (void **var_addr : var_addrs) {
+  for (int i = 0; i < var_addrs.Size(); i++) {
+    void **var_addr = var_addrs[i];
     shadow->add_shadow(*var_addr, 1);
     if (!is_return) {
       RefCountAnalysis analysis_result = shadow->shadow_analysis(*var_addr);
-      if (std::get<1>(analysis_result) == RefCountZero)
-        ref_count_zero_addrs->push_back(*var_addr);
+      if (analysis_result.ExceptTy == RefCountZero)
+        ref_count_zero_addrs->PushBack(*var_addr);
     } else if (*var_addr != ret_addr) {
       check_memory_leak(*var_addr);
     }
@@ -172,21 +187,24 @@ Plsan::free_stack_variables(void *ret_addr, bool is_return,
     return nullptr;
 }
 
-std::vector<void *> *Plsan::free_stack_array(void **arr_addr, size_t size,
-                                             void *ret_addr, bool is_return) {
+__sanitizer::Vector<void *> *Plsan::free_stack_array(void **arr_addr,
+                                                     size_t size,
+                                                     void *ret_addr,
+                                                     bool is_return) {
   // This method almost same with free_stack_variables method, but it is for
   // arrays in stack. "arr_addr" arg has array start address "size" arg has
   // array size
 
-  std::vector<void *> *ref_count_zero_addrs = new std::vector<void *>();
+  __sanitizer::Vector<void *> *ref_count_zero_addrs =
+      new __sanitizer::Vector<void *>();
 
   for (int i = 0; i < size; i++) {
     void *ptr_value = ptr_array_value(arr_addr, i);
     shadow->add_shadow(ptr_value, 1);
     if (!is_return) {
       RefCountAnalysis analysis_result = shadow->shadow_analysis(ptr_value);
-      if (std::get<1>(analysis_result) == RefCountZero)
-        ref_count_zero_addrs->push_back(ptr_value);
+      if (analysis_result.ExceptTy == RefCountZero)
+        ref_count_zero_addrs->PushBack(ptr_value);
     } else if (ptr_value != ret_addr) {
       check_memory_leak(ptr_value);
     }
@@ -207,7 +225,7 @@ void Plsan::check_returned_or_stored_value(void *ret_ptr_addr,
 
   RefCountAnalysis analysis_result = shadow->shadow_analysis(ret_ptr_addr);
   // check address type
-  if (std::get<0>(analysis_result) == NonDynAlloc) {
+  if (analysis_result.addrTy == NonDynAlloc) {
     return;
   } else if (!shadow->shadow_value_is_equal(ret_ptr_addr, compare_ptr_addr)) {
     check_memory_leak(analysis_result);
@@ -217,14 +235,14 @@ void Plsan::check_returned_or_stored_value(void *ret_ptr_addr,
 void Plsan::check_memory_leak(void *addr) {
   RefCountAnalysis analysis_result = shadow->shadow_analysis(addr);
   // check exception type
-  if (std::get<1>(analysis_result) == RefCountZero) {
+  if (analysis_result.ExceptTy == RefCountZero) {
     handler->exception_check(analysis_result);
   }
 }
 
 void Plsan::check_memory_leak(RefCountAnalysis analysis_result) {
   // check exception type
-  if (std::get<1>(analysis_result) == RefCountZero) {
+  if (analysis_result.ExceptTy == RefCountZero) {
     handler->exception_check(analysis_result);
   }
 }

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -4,8 +4,6 @@
 #include "plsan_handler.h"
 #include "plsan_shadow.h"
 
-#include <tuple>
-
 namespace __plsan {
 
 class Plsan {
@@ -18,10 +16,11 @@ public:
   void init_refcnt(void *addr, size_t size);
   void fini_refcnt(void *addr);
   void reference_count(void **lhs, void *rhs);
-  std::vector<void *> *free_stack_variables(void *ret_addr, bool is_return,
-                                            std::vector<void **> var_addrs);
-  std::vector<void *> *free_stack_array(void **arr_addr, size_t size,
-                                        void *ret_addr, bool is_return);
+  __sanitizer::Vector<void *> *
+  free_stack_variables(void *ret_addr, bool is_return,
+                       __sanitizer::Vector<void **> &var_addrs);
+  __sanitizer::Vector<void *> *free_stack_array(void **arr_addr, size_t size,
+                                                void *ret_addr, bool is_return);
   void check_returned_or_stored_value(void *ret_ptr_addr,
                                       void *compare_ptr_addr);
   void check_memory_leak(void *addr);

--- a/compiler-rt/lib/plsan/plsan_handler.cpp
+++ b/compiler-rt/lib/plsan/plsan_handler.cpp
@@ -6,7 +6,7 @@ namespace __plsan {
 void PlsanHandler::exception_check(RefCountAnalysis ref_count_analysis) {
   AddrType addrType;
   ExceptionType exceptionType;
-  std::tie(addrType, exceptionType) = ref_count_analysis;
+  // std::tie(addrType, exceptionType) = ref_count_analysis;
   print_stack_trace(NULL, 0, std::cerr);
   exit(EXIT_FAILURE);
 }

--- a/compiler-rt/lib/plsan/plsan_handler.cpp
+++ b/compiler-rt/lib/plsan/plsan_handler.cpp
@@ -6,7 +6,7 @@ namespace __plsan {
 void PlsanHandler::exception_check(RefCountAnalysis ref_count_analysis) {
   AddrType addrType;
   ExceptionType exceptionType;
-  print_stack_trace(NULL, 0, std::cerr);
+  // print_stack_trace(NULL, 0, std::cerr);
   exit(EXIT_FAILURE);
 }
 
@@ -21,43 +21,45 @@ void PlsanHandler::exception_check(RefCountAnalysis ref_count_analysis) {
 //     #1 0x401150 in main /home/hyeyoo/precise-leak-sanitizer/main.c:7
 //     #2 0x7fd7dd83feaf in __libc_start_call_main (/lib64/libc.so.6+0x3feaf)
 
-void PlsanHandler::print_stack_trace(void *alloc_addr, size_t alloc_size,
-                                     std::ostream &os) {
-  os << "=================================================================\n";
+// void PlsanHandler::print_stack_trace(void *alloc_addr, size_t alloc_size,
+//                                      std::ostream &os) {
+//   os <<
+//   "=================================================================\n";
 
-  os << "==<" << getpid()
-     << ">==ERROR: PreciseLeakSanitizer: detected memory leaks\n";
+//   os << "==<" << getpid()
+//      << ">==ERROR: PreciseLeakSanitizer: detected memory leaks\n";
 
-  os << "\n";
-  os << "Leak of " << alloc_size << " byte(s) in an object (<" << alloc_addr
-     << ">) allocated from:\n";
-  stack_trace(alloc_addr, os);
+//   os << "\n";
+//   os << "Leak of " << alloc_size << " byte(s) in an object (<" << alloc_addr
+//      << ">) allocated from:\n";
+//   stack_trace(alloc_addr, os);
 
-  StackTrace st;
-  TraceResolver tr;
-  st.load_here();
-  tr.load_stacktrace(st);
+//   StackTrace st;
+//   TraceResolver tr;
+//   st.load_here();
+//   tr.load_stacktrace(st);
 
-  void *leak_addr = tr.resolve(st[0]).addr;
+//   void *leak_addr = tr.resolve(st[0]).addr;
 
-  os << "\n";
-  os << "Last reference to the object (<" << leak_addr << ">) lost at:\n";
-  stack_trace(leak_addr, os);
-}
+//   os << "\n";
+//   os << "Last reference to the object (<" << leak_addr << ">) lost at:\n";
+//   stack_trace(leak_addr, os);
+// }
 
-void PlsanHandler::stack_trace(void *addr, std::ostream &os) {
-  StackTrace st;
-  TraceResolver tr;
+// void PlsanHandler::stack_trace(void *addr, std::ostream &os) {
+//   StackTrace st;
+//   TraceResolver tr;
 
-  addr == NULL ? st.load_here() : st.load_from(addr);
-  tr.load_stacktrace(st);
+//   addr == NULL ? st.load_here() : st.load_from(addr);
+//   tr.load_stacktrace(st);
 
-  for (size_t i = 0; i < st.size(); ++i) {
-    ResolvedTrace trace = tr.resolve(st[i]);
+//   for (size_t i = 0; i < st.size(); ++i) {
+//     ResolvedTrace trace = tr.resolve(st[i]);
 
-    os << "    #" << i << " " << trace.addr << " in " << trace.object_function
-       << " " << trace.object_filename << ":" << trace.source.line << "\n";
-  }
-}
+//     os << "    #" << i << " " << trace.addr << " in " <<
+//     trace.object_function
+//        << " " << trace.object_filename << ":" << trace.source.line << "\n";
+//   }
+// }
 
 } // namespace __plsan

--- a/compiler-rt/lib/plsan/plsan_handler.cpp
+++ b/compiler-rt/lib/plsan/plsan_handler.cpp
@@ -6,7 +6,6 @@ namespace __plsan {
 void PlsanHandler::exception_check(RefCountAnalysis ref_count_analysis) {
   AddrType addrType;
   ExceptionType exceptionType;
-  // std::tie(addrType, exceptionType) = ref_count_analysis;
   print_stack_trace(NULL, 0, std::cerr);
   exit(EXIT_FAILURE);
 }

--- a/compiler-rt/lib/plsan/plsan_handler.h
+++ b/compiler-rt/lib/plsan/plsan_handler.h
@@ -15,7 +15,7 @@ enum ExceptionType { None, RefCountZero };
 
 struct RefCountAnalysis {
   AddrType addrTy;
-  ExceptionType ExceptTy;
+  ExceptionType exceptTy;
 };
 
 class PlsanHandler {

--- a/compiler-rt/lib/plsan/plsan_handler.h
+++ b/compiler-rt/lib/plsan/plsan_handler.h
@@ -2,10 +2,11 @@
 #define PLSAN_HANDLER_H
 
 #include "lsan/lsan_common.h"
+#include <stdint.h>
 
-#include "lib/backward.h"
+// #include "lib/backward.h"
 
-using namespace backward;
+// using namespace backward;
 
 namespace __plsan {
 
@@ -21,8 +22,8 @@ struct RefCountAnalysis {
 class PlsanHandler {
 public:
   void exception_check(RefCountAnalysis ref_count_analysis);
-  void print_stack_trace(void *alloc_addr, size_t alloc_size, std::ostream &os);
-  void stack_trace(void *addr, std::ostream &os);
+  // void print_stack_trace(void *alloc_addr, size_t alloc_size, std::ostream
+  // &os); void stack_trace(void *addr, std::ostream &os);
 };
 
 } // namespace __plsan

--- a/compiler-rt/lib/plsan/plsan_handler.h
+++ b/compiler-rt/lib/plsan/plsan_handler.h
@@ -1,8 +1,7 @@
 #ifndef PLSAN_HANDLER_H
 #define PLSAN_HANDLER_H
 
-#include <iostream>
-#include <tuple>
+#include "lsan/lsan_common.h"
 
 #include "lib/backward.h"
 
@@ -14,7 +13,10 @@ enum AddrType { NonDynAlloc, DynAlloc };
 enum ExceptionType { None, RefCountZero };
 // Something stack trace data structure here.
 
-using RefCountAnalysis = std::tuple<AddrType, ExceptionType /*, StackTrace*/>;
+struct RefCountAnalysis {
+  AddrType addrTy;
+  ExceptionType ExceptTy;
+};
 
 class PlsanHandler {
 public:


### PR DESCRIPTION
We cannot use sanitizer code with STL, so we remove STL and replace with sanitizer common library.

And this branch is not completed, but these commits are critical for other implementation, so open pr now.