### PR TITLE
Simplify handling local variables

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -301,6 +301,8 @@ __attribute__((constructor(0))) void __plsan_init() {
   plsan_inited = true;
 }
 
+void __plsan_check_memory_leak(void *addr) { plsan->check_memory_leak(addr); }
+
 } // namespace __plsan
 
 void __sanitizer::BufferedStackTrace::UnwindImpl(uptr pc, uptr bp,

--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -3,6 +3,8 @@
 
 #include <cstdarg>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <pthread.h>
 
@@ -60,8 +62,10 @@ extern "C" void __plsan_lazy_check(LazyCheckInfo *lazy_check_info,
       lazy_check_info->RefCountZeroAddrs;
 
   for (int i = 0; i < lazy_check_addr_list->Size(); i++) {
-    if ((*lazy_check_addr_list)[i] != ret_addr)
-      throw ret_addr;
+    if ((*lazy_check_addr_list)[i] != ret_addr) {
+      printf("PreciseLeakSanitizer\n");
+      exit(EXIT_FAILURE);
+    }
   }
 
   delete lazy_check_addr_list;

--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -81,12 +81,20 @@ extern "C" void __plsan_check_memory_leak(void *addr) {
   plsan->check_memory_leak(addr);
 }
 
-extern "C" void __plsan_memcpy_refcnt(void *dest, void *src, size_t count) {
-  plsan->memcpy_refcnt(dest, src, count);
-}
-
 extern "C" void *__plsan_memset_wrapper(void *ptr, int value, size_t num) {
   return plsan->memset_wrapper(ptr, value, num);
+}
+
+extern "C" void *__plsan_memset(void *ptr, int value, size_t num) {
+  return plsan->plsan_memset(ptr, value, num);
+}
+
+extern "C" void *__plsan_memcpy(void *dest, void *src, size_t count) {
+  return plsan->plsan_memcpy(dest, src, count);
+}
+
+extern "C" void *__plsan_memmove(void *dest, void *src, size_t num) {
+  return plsan->plsan_memmove(dest, src, num);
 }
 
 namespace __plsan {
@@ -95,9 +103,7 @@ Plsan::Plsan() {
   handler = new PlsanHandler();
 }
 
-Plsan::~Plsan() {
-  delete handler;
-}
+Plsan::~Plsan() { delete handler; }
 
 void Plsan::reference_count(void **lhs, void *rhs) {
   // Ref count with Shadow class update_shadow method.
@@ -178,12 +184,14 @@ void Plsan::check_memory_leak(RefCountAnalysis analysis_result) {
   }
 }
 
-void Plsan::memcpy_refcnt(void *dest, void *src, size_t count) {
-  for (int i = 0; i < count / 8; i++) {
-    void *src_i = plsan->ptr_array_value(src, i * 8);
-    void *dest_i = plsan->ptr_array_value(dest, i * 8);
-    plsan->reference_count(&dest_i, src_i);
-  }
+void *Plsan::plsan_memset(void *ptr, int value, size_t num) { return nullptr; }
+
+void *Plsan::plsan_memcpy(void *dest, void *src, size_t count) {
+  return nullptr;
+}
+
+void *Plsan::plsan_memmove(void *dest, void *src, size_t num) {
+  return nullptr;
 }
 
 void *Plsan::ptr_array_value(void *array_start_addr, size_t index) {

--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -85,6 +85,10 @@ extern "C" void __plsan_memcpy_refcnt(void *dest, void *src, size_t count) {
   plsan->memcpy_refcnt(dest, src, count);
 }
 
+extern "C" void *__plsan_memset_wrapper(void *ptr, int value, size_t num) {
+  return plsan->memset_wrapper(ptr, value, num);
+}
+
 namespace __plsan {
 
 Plsan::Plsan() {
@@ -205,6 +209,11 @@ RefCountAnalysis Plsan::leak_analysis(const void *ptr) {
 
   RefCountAnalysis result = {addr_type, exception_type};
   return result;
+}
+
+// This function is needed to not intercept our instrumented memset.
+void *Plsan::memset_wrapper(void *ptr, int value, size_t num) {
+  return internal_memset(ptr, value, num);
 }
 
 void PlsanInstallAtForkHandler() {

--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -184,14 +184,49 @@ void Plsan::check_memory_leak(RefCountAnalysis analysis_result) {
   }
 }
 
-void *Plsan::plsan_memset(void *ptr, int value, size_t num) { return nullptr; }
+void *Plsan::plsan_memset(void *ptr, int value, size_t num) {
+  uptr *ptr_t = (uptr *)ptr;
+  uptr *next_ptr = ptr_t;
+  uptr *end_ptr = ptr_t + (num / 8);
+  while (next_ptr < end_ptr) {
+    plsan->reference_count((void **)next_ptr, nullptr);
+    next_ptr++;
+  }
+  return internal_memset(ptr, value, num);
+}
 
 void *Plsan::plsan_memcpy(void *dest, void *src, size_t count) {
-  return nullptr;
+  int i = 0;
+  int j = 0;
+  int end = count / sizeof(void *);
+  uptr **dest_t = (uptr **)dest;
+  uptr **src_t = (uptr **)src;
+  while (i < end) {
+    void **dest_i = (void **)(dest_t + i);
+    void **src_i = (void **)(src_t + j);
+    if (src_i == (void **)dest_t) {
+      j = 0;
+      src_i = (void **)src_t;
+    }
+    plsan->reference_count(dest_i, *src_i);
+    i++;
+    j++;
+  }
+  return internal_memcpy(dest, src, count);
 }
 
 void *Plsan::plsan_memmove(void *dest, void *src, size_t num) {
-  return nullptr;
+  int i = 0;
+  int end = num / sizeof(void *);
+  uptr **dest_t = (uptr **)dest;
+  uptr **src_t = (uptr **)src;
+  while (i < end) {
+    void **dest_i = (void **)(dest_t + i);
+    void **src_i = (void **)(src_t + i);
+    plsan->reference_count(dest_i, *src_i);
+    i++;
+  }
+  return internal_memmove(dest, src, num);
 }
 
 void *Plsan::ptr_array_value(void *array_start_addr, size_t index) {

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -29,6 +29,7 @@ public:
   void check_memory_leak(RefCountAnalysis analysis_result);
   void memcpy_refcnt(void *dest, void *src, size_t count);
   RefCountAnalysis leak_analysis(const void *ptr);
+  void *memset_wrapper(void *ptr, int value, size_t num);
 
 private:
   PlsanHandler *handler;

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -64,6 +64,7 @@ int plsan_posix_memalign(void **memptr, uptr alignment, uptr size,
                          StackTrace *stack);
 void plsan_free(void *ptr);
 void __plsan_init();
+void __plsan_check_memory_leak(void *addr);
 void InitializeInterceptors();
 void InstallAtExitCheckLeaks();
 

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -43,7 +43,7 @@ extern bool plsan_init_is_running;
 void PlsanAllocatorInit();
 void PlsanAllocatorLock();
 void PlsanAllocatorUnlock();
-void UpdateReference(const void *lhs, const void *rhs);
+void UpdateReference(void **lhs, void *rhs);
 bool PtrIsAllocatedFromPlsan(const void *p);
 bool IsSameObject(const void *p, const void *q);
 void IncRefCount(const void *p);

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -20,11 +20,9 @@ public:
   // Instrumentation function
 
   void reference_count(void **lhs, void *rhs);
-  __sanitizer::Vector<void *> *
-  free_stack_variables(void *ret_addr, bool is_return,
-                       __sanitizer::Vector<void **> &var_addrs);
-  __sanitizer::Vector<void *> *free_stack_array(void **arr_addr, size_t size,
-                                                void *ret_addr, bool is_return);
+  __sanitizer::Vector<void *> *free_local_variable(void **arr_addr, size_t size,
+                                                   void *ret_addr,
+                                                   bool is_return);
   void check_returned_or_stored_value(void *ret_ptr_addr,
                                       void *compare_ptr_addr);
   void check_memory_leak(void *addr);

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -27,9 +27,12 @@ public:
                                       void *compare_ptr_addr);
   void check_memory_leak(void *addr);
   void check_memory_leak(RefCountAnalysis analysis_result);
-  void memcpy_refcnt(void *dest, void *src, size_t count);
   RefCountAnalysis leak_analysis(const void *ptr);
   void *memset_wrapper(void *ptr, int value, size_t num);
+
+  void *plsan_memset(void *ptr, int value, size_t num);
+  void *plsan_memcpy(void *dest, void *src, size_t count);
+  void *plsan_memmove(void *dest, void *src, size_t num);
 
 private:
   PlsanHandler *handler;

--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -13,6 +13,7 @@
 
 #include "plsan_allocator.h"
 #include "lsan/lsan_common.h"
+#include "plsan.h"
 #include "sanitizer_common/sanitizer_allocator.h"
 #include "sanitizer_common/sanitizer_allocator_checks.h"
 #include "sanitizer_common/sanitizer_allocator_report.h"
@@ -225,8 +226,10 @@ static void Deallocate(void *p) {
   CHECK(allocator.GetBlockBegin(p) == p);
   void **ptr = reinterpret_cast<void **>(p);
   while ((uintptr_t)ptr < (uintptr_t)p + m->GetRequestedSize()) {
-    if (allocator.PointerIsMine(*ptr))
+    if (allocator.PointerIsMine(*ptr)) {
       DecRefCount(*ptr);
+      __plsan_check_memory_leak(*ptr);
+    }
     ptr++;
   }
 

--- a/compiler-rt/lib/plsan/plsan_thread.cpp
+++ b/compiler-rt/lib/plsan/plsan_thread.cpp
@@ -122,8 +122,8 @@ void LockThreads() {
 }
 
 void UnlockThreads() {
-  __plsan::plsanThreadRegistry().Unlock();
   __plsan::plsanThreadArgRetval().Unlock();
+  __plsan::plsanThreadRegistry().Unlock();
 }
 
 void EnsureMainThreadIDIsCorrect() { __plsan::EnsureMainThreadIDIsCorrect(); }

--- a/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
@@ -43,12 +43,14 @@ private:
   FunctionType *CheckMemoryLeakFnTy;
   FunctionType *MemcpyRefcntFnTy;
   FunctionType *ReallocInstrumentFnTy;
+  FunctionType *MemsetWrapperFnTy;
   FunctionCallee StoreFn;
   FunctionCallee FreeLocalVariableFn;
   FunctionCallee LazyCheckFn;
   FunctionCallee CheckReturnedOrStoredValueFn;
   FunctionCallee CheckMemoryLeakFn;
   FunctionCallee MemcpyRefcntFn;
+  FunctionCallee MemsetWrapperFn;
   StringRef StoreFnName = "__plsan_store";
   StringRef FreeLocalVariableFnName = "__plsan_free_local_variable";
   StringRef LazyCheckFnName = "__plsan_lazy_check";
@@ -56,6 +58,7 @@ private:
       "__plsan_check_returned_or_stored_value";
   StringRef CheckMemoryLeakFnName = "__plsan_check_memory_leak";
   StringRef MemcpyRefcntFnName = "__plsan_memcpy_refcnt";
+  StringRef MemsetWrapperFnName = "__plsan_memset_wrapper";
 
   bool initializeModule();
   CallInst *CreateCallWithMetaData(IRBuilder<> &Builder, FunctionCallee Fn,

--- a/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
@@ -12,8 +12,8 @@
 
 using namespace llvm;
 
-using ArrayAddrInfo =
-    std::tuple</*ArrayStartPointer=*/Value *, /*ArraySize*/ Value *>;
+using VarAddrSizeInfo =
+    std::tuple</*StartPointer=*/Value *, /*SizeInBytes*/ Value *>;
 
 class PreciseLeakSanitizer {
 private:
@@ -37,23 +37,20 @@ private:
   FunctionType *AllocFnTy;
   FunctionType *FreeFnTy;
   FunctionType *StoreFnTy;
-  FunctionType *FreeStackVariablesFnTy;
-  FunctionType *FreeStackArrayFnTy;
+  FunctionType *FreeLocalVariableFnTy;
   FunctionType *LazyCheckFnTy;
   FunctionType *CheckReturnedOrStoredValueFnTy;
   FunctionType *CheckMemoryLeakFnTy;
   FunctionType *MemcpyRefcntFnTy;
   FunctionType *ReallocInstrumentFnTy;
   FunctionCallee StoreFn;
-  FunctionCallee FreeStackVariablesFn;
-  FunctionCallee FreeStackArrayFn;
+  FunctionCallee FreeLocalVariableFn;
   FunctionCallee LazyCheckFn;
   FunctionCallee CheckReturnedOrStoredValueFn;
   FunctionCallee CheckMemoryLeakFn;
   FunctionCallee MemcpyRefcntFn;
   StringRef StoreFnName = "__plsan_store";
-  StringRef FreeStackVariablesFnName = "__plsan_free_stack_variables";
-  StringRef FreeStackArrayFnName = "__plsan_free_stack_array";
+  StringRef FreeLocalVariableFnName = "__plsan_free_local_variable";
   StringRef LazyCheckFnName = "__plsan_lazy_check";
   StringRef CheckReturnedOrStoredValueFnName =
       "__plsan_check_returned_or_stored_value";
@@ -76,13 +73,11 @@ public:
   void visitStoreInst(StoreInst &I);
   void visitReturnInst(ReturnInst &I);
   void visitCallInst(CallInst &I);
-  void pushNewLocalPtrVarListStack();
-  void pushNewLocalPtrArrListStack();
+  void pushNewLocalVarListStack();
 
 private:
   PreciseLeakSanitizer &Plsan;
-  std::stack<std::vector<Value *>> LocalPtrVarListStack;
-  std::stack<std::vector<ArrayAddrInfo>> LocalPtrArrListStack;
+  std::stack<std::vector<VarAddrSizeInfo>> LocalVarListStack;
   std::stack<CallInst *> LazyCheckInfoStack;
   Instruction *InstructionTraceTopDown(Instruction *I);
   void visitCallMemset(CallInst &I);


### PR DESCRIPTION
Simplify initialization of local variables and decreasing reference counts of local variables. Regardless of the type (even for non-pointer types), just initialize/finialize (check memory leak) using only the address and the size of an object. It simplifies the code pretty much and unnecessary instrumentation for variables that does not contain pointers can be optimized later.

Also, bug fixes are included for the PLSan allocator and runtime library.

9 false negative cases are fixed by this PR:

    - testcases/c++/leak/class-1.cpp
    - testcases/c++/leak/class-2.cpp
    - testcases/c/leak/ftype-4.c
    - testcases/c/leak/var_arr-5.c
    - testcases/c/leak/var_arr-6.c
    - testcases/c/leak/var_arr-2.c
    - testcases/c/leak/var_arr-4.c
    - testcases/c/leak/ftype-3.c
    - testcases/c/leak/var_arr-3.c