### PR TITLE
testcases: consider DEADLYSIGNAL as crash

### DIFF
--- a/scripts/test-plsan.sh
+++ b/scripts/test-plsan.sh
@@ -77,8 +77,7 @@ for test_case in $test_cases; do
     diff_t=$(echo "$end_t" - "$start_t" | bc -l | cut -c -4)
 
     echo -n " [${diff_t}s]"
-
-    if [ "$testcase_exitcode" != "0" ] && [[ $sanitizer_output != *"LeakSanitizer"* ]]; then
+    if [[ "$testcase_exitcode" != "0" && $sanitizer_output != *"LeakSanitizer"* ]] || [[ $sanitizer_output == *"DEADLYSIGNAL"* ]]; then
       echo " [Crash] $sanitizer_output"
       ((_CRASH++))
       _CRASH_TC_LIST+=("    - $test_case")


### PR DESCRIPTION
Since commit d24870bb1bb ("compiler-rt: Add precise leak report in lsan"), when the process is dead, PreciseLeakSanitizer report is printed.

If there's "DEADLYSIGNAL" in the output, consider this as crash instead. The current script consider this as leak because of the "PreciseLeakSanitizer" signature string in the output.