### PR TITLE
Revert "55 debugging from the hell"

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -8,7 +8,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <pthread.h>
-#include <new>
 
 #include "lsan/lsan_common.h"
 #include "sanitizer_common/sanitizer_atomic.h"
@@ -32,8 +31,7 @@ struct LazyCheckInfo {
 
 /* Initialization routines called before main() */
 __attribute__((constructor)) void __plsan_init() {
-  void *mem = __sanitizer::InternalAlloc(sizeof(__plsan::Plsan));
-  plsan = new (mem) __plsan::Plsan();
+  plsan = (__plsan::Plsan *)__sanitizer::InternalAlloc(sizeof(__plsan::Plsan));
 }
 
 /* finialization routines called after main() */
@@ -56,7 +54,6 @@ extern "C" LazyCheckInfo *__plsan_free_local_variable(void **arr_start_addr,
   // __builtin_return_address(0) will return program counter
   LazyCheckInfo *lazy_check_info =
       (LazyCheckInfo *)__sanitizer::InternalAlloc(sizeof(LazyCheckInfo));
-  CHECK(lazy_check_info);
   lazy_check_info->RefCountZeroAddrs = ref_count_zero_addrs;
   if (is_return) {
     __sanitizer::InternalFree(lazy_check_info);
@@ -140,24 +137,20 @@ __sanitizer::Vector<void *> *Plsan::free_local_variable(void **addr,
   //    count. We do not check memory leak (lazy check). -> There is some cases
   //    that return restored stack value.
 
-  void *mem =
+  __sanitizer::Vector<void *> *ref_count_zero_addrs =
       (__sanitizer::Vector<void *> *)__sanitizer::InternalAlloc(
           sizeof(__sanitizer::Vector<void *>));
-  CHECK(mem);
-  __sanitizer::Vector<void *> *ref_count_zero_addrs =
-      new (mem) __sanitizer::Vector<void *>();
 
-  void **ptr = addr;
-  while (ptr + 1 <= addr + size / (sizeof(void *))) {
-    DecRefCount(ptr);
+  for (size_t i = 0; sizeof(void *) * i < size; i++) {
+    void *ptr_value = ptr_array_value(addr, i);
+    DecRefCount(ptr_value);
     if (is_return == false) {
-      RefCountAnalysis analysis_result = leak_analysis(ptr);
+      RefCountAnalysis analysis_result = leak_analysis(ptr_value);
       if (analysis_result.exceptTy == RefCountZero)
-        ref_count_zero_addrs->PushBack(ptr);
-    } else if (ptr != ret_addr) {
-      check_memory_leak(ptr);
+        ref_count_zero_addrs->PushBack(ptr_value);
+    } else if (ptr_value != ret_addr) {
+      check_memory_leak(ptr_value);
     }
-    ptr++;
   }
 
   if (is_return == false) {
@@ -242,6 +235,12 @@ void *Plsan::plsan_memmove(void *dest, void *src, size_t num) {
     i++;
   }
   return internal_memmove(dest, src, num);
+}
+
+void *Plsan::ptr_array_value(void *array_start_addr, size_t index) {
+  // void * type cannot add with integer. So casting to int *.
+  int64_t *array_addr = (int64_t *)array_start_addr;
+  return (void *)(*(array_addr + index));
 }
 
 RefCountAnalysis Plsan::leak_analysis(const void *ptr) {

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -41,6 +41,9 @@ public:
   void *plsan_memset(void *ptr, int value, size_t num);
   void *plsan_memcpy(void *dest, void *src, size_t count);
   void *plsan_memmove(void *dest, void *src, size_t num);
+
+private:
+  void *ptr_array_value(void *array_start_addr, size_t index);
 };
 
 extern bool plsan_inited;


### PR DESCRIPTION
Reverts hygoni/precise-leak-sanitizer#58

Because of this merge, the PreciseLeakSanitizer doesn't report leak location,
(but still the passes the test-plsan.sh script)