### PR TITLE
testcases: add __builtin_alloca() in non-entry basic blockc case

### DIFF
--- a/testcases/c/functional/builtin_alloca/builtin_alloca.c
+++ b/testcases/c/functional/builtin_alloca/builtin_alloca.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+
+int main(void)
+{
+  srand(time(NULL));
+
+  int r = rand();
+  if (r % 2 == 9999 /* This is intentional */) {
+    int *p = __builtin_alloca(sizeof(int));
+    *p = -1;
+  } else {
+    double *q = __builtin_alloca(sizeof(double));
+    *q = -1.0;
+  }
+}


### PR DESCRIPTION
As same as the crash in 502.gcc_r SPEC CPU2017 case, if a builtin alloca is not executed - a matching __plsan_free_local_variable() crashes. This is a testcase for this.