### PR TITLE
Optimization: memset_wrapper to builtin memset

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -91,10 +91,6 @@ extern "C" void __plsan_check_memory_leak(void *addr) {
   plsan->check_memory_leak(addr);
 }
 
-extern "C" void *__plsan_memset_wrapper(void *ptr, int value, size_t num) {
-  return plsan->memset_wrapper(ptr, value, num);
-}
-
 extern "C" void *__plsan_memset(void *ptr, int value, size_t num) {
   return plsan->plsan_memset(ptr, value, num);
 }
@@ -271,11 +267,6 @@ RefCountAnalysis Plsan::leak_analysis(const void *ptr) {
 
   RefCountAnalysis result = {addr_type, exception_type, stack_trace_id};
   return result;
-}
-
-// This function is needed to not intercept our instrumented memset.
-void *Plsan::memset_wrapper(void *ptr, int value, size_t num) {
-  return internal_memset(ptr, value, num);
 }
 
 void PlsanInstallAtForkHandler() {

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -36,7 +36,6 @@ public:
   void check_memory_leak(void *addr);
   void check_memory_leak(RefCountAnalysis analysis_result);
   RefCountAnalysis leak_analysis(const void *ptr);
-  void *memset_wrapper(void *ptr, int value, size_t num);
 
   void *plsan_memset(void *ptr, int value, size_t num);
   void *plsan_memcpy(void *dest, void *src, size_t count);

--- a/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
@@ -43,7 +43,6 @@ private:
   FunctionType *CheckReturnedOrStoredValueFnTy;
   FunctionType *CheckMemoryLeakFnTy;
   FunctionType *ReallocInstrumentFnTy;
-  FunctionType *MemsetWrapperFnTy;
   FunctionType *MemsetFnTy;
   FunctionType *MemcpyFnTy;
   FunctionType *MemmoveFnTy;
@@ -52,7 +51,6 @@ private:
   FunctionCallee LazyCheckFn;
   FunctionCallee CheckReturnedOrStoredValueFn;
   FunctionCallee CheckMemoryLeakFn;
-  FunctionCallee MemsetWrapperFn;
   FunctionCallee MemsetFn;
   FunctionCallee MemcpyFn;
   FunctionCallee MemmoveFn;
@@ -62,7 +60,6 @@ private:
   StringRef CheckReturnedOrStoredValueFnName =
       "__plsan_check_returned_or_stored_value";
   StringRef CheckMemoryLeakFnName = "__plsan_check_memory_leak";
-  StringRef MemsetWrapperFnName = "__plsan_memset_wrapper";
   StringRef MemsetFnName = "__plsan_memset";
   StringRef MemcpyFnName = "__plsan_memcpy";
   StringRef MemmoveFnName = "__plsan_memmove";


### PR DESCRIPTION
We implement memset_wrapper to avoid memset function intercepting last time. But now we don't intercept memset, so memset_wrapper just make overhead.

test-arraylist: 670.30 -> 665.20
test-avl-tree: 682.06 -> 665.32
test-binary-heap: 231.04 -> 209.20
test-binomial-heap: 183.66 -> 176.72
test-bloom-filter: 4.41 -> 4.29
test-compare-functions: 3.76 -> 4.17
test-hash-functions: 14.54 -> 15.65
test-hash-table: 120.21 -> 117.80
test-list: 6.84 -> 5.22
test-queue: 111.42 -> 100.20
test-rb-tree: 105.41 -> 131.28
test-set: 118.76 -> 108.76
test-slist: 5.89 -> 5.31
test-sortedarray: 7.27 -> 6.98
test-trie: 19.17 -> 18.56