### PR TITLE
66 minor optimizations

### DIFF
--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -63,8 +63,8 @@ void DecRefCount(const void *p) {
   m->DecRefCount();
 }
 
-bool PtrIsAllocatedFromPlsan(const void *p) {
-  if (!allocator.PointerIsMine(p))
+bool inline PtrIsAllocatedFromPlsan(const void *p) {
+  if (!PointerIsFromPrimary(reinterpret_cast<uptr>(p)))
     return false;
 
   struct Metadata *m = GetMetadata(p);

--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -38,9 +38,6 @@ void GetAllocatorCacheRange(uptr *begin, uptr *end) {
 }
 
 static Metadata *GetMetadata(const void *p) {
-  if (!allocator.PointerIsMine(p))
-    return nullptr;
-
   p = allocator.GetBlockBegin(p);
   if (!p)
     return nullptr;

--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -75,7 +75,19 @@ bool PtrIsAllocatedFromPlsan(const void *p) {
 }
 
 bool IsSameObject(const void *x, const void *y) {
-  return GetMetadata(x) == GetMetadata(y);
+  if (!x || !y)
+    return false;
+
+  void *begin = allocator.GetBlockBegin(x);
+  if (!begin)
+    return false;
+
+  struct Metadata *m =
+      reinterpret_cast<struct Metadata *>(allocator.GetMetaData(begin));
+  if (!m)
+    return false;
+
+  return begin <= y && (uptr)y < (uptr)begin + m->GetRequestedSize();
 }
 
 uint8_t GetRefCount(const void *p) {


### PR DESCRIPTION
Some minor optimizations.

The biggest optimization is commit 30a6aaf66c5bd3c35d63fe37a37131cbd3e7c05b,
but others also adds up :)

Performance data:
======= before =======
test-arraylist : 696.91
test-avl-tree : 659.00
test-binary-heap : 251.29
test-binomial-heap : 190.36
test-bloom-filter : 4.20
test-compare-functions : 3.74
test-hash-functions : 20.80
test-hash-table : 120.31
test-list : 8.88
test-queue : 128.11
test-rb-tree : 186.42
test-set : 122.90
test-slist : 10.59
test-sortedarray : 10.89
test-trie : 18.90
=======after =======
test-arraylist : 146.57
test-avl-tree : 312.88
test-binary-heap : 118.90
test-binomial-heap : 85.22
test-bloom-filter : 6.44
test-compare-functions : 5.39
test-hash-functions : 15.69
test-hash-table : 55.86
test-list : 7.01
test-queue : 79.85
test-rb-tree : 81.97
test-set : 52.07
test-slist : 7.04
test-sortedarray : 6.79
test-trie : 9.31