### PR TITLE
compiler-rt: Do not use singleton pattern for PLSan class

### DIFF
--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -22,27 +22,17 @@ struct RefCountAnalysis {
   u32 stack_trace_id;
 };
 
-class Plsan {
-public:
-  Plsan();
-  ~Plsan();
+void reference_count(void **lhs, void *rhs);
+__sanitizer::Vector<void *> *
+free_local_variable(void **arr_addr, uptr size, void *ret_addr, bool is_return);
+void check_returned_or_stored_value(void *ret_ptr_addr, void *compare_ptr_addr);
+void check_memory_leak(Metadata *metadata);
+void check_memory_leak(RefCountAnalysis analysis_result);
+RefCountAnalysis leak_analysis(Metadata *metadata);
 
-  // Instrumentation function
-
-  void reference_count(void **lhs, void *rhs);
-  __sanitizer::Vector<void *> *free_local_variable(void **arr_addr, uptr size,
-                                                   void *ret_addr,
-                                                   bool is_return);
-  void check_returned_or_stored_value(void *ret_ptr_addr,
-                                      void *compare_ptr_addr);
-  void check_memory_leak(Metadata *metadata);
-  void check_memory_leak(RefCountAnalysis analysis_result);
-  RefCountAnalysis leak_analysis(Metadata *metadata);
-
-  void *plsan_memset(void *ptr, int value, uptr num);
-  void *plsan_memcpy(void *dest, void *src, uptr count);
-  void *plsan_memmove(void *dest, void *src, uptr num);
-};
+void *plsan_memset(void *ptr, int value, uptr num);
+void *plsan_memcpy(void *dest, void *src, uptr count);
+void *plsan_memmove(void *dest, void *src, uptr num);
 
 extern bool plsan_inited;
 extern bool plsan_init_is_running;


### PR DESCRIPTION
While initial implementation of the runtime library adopted singleton design pattern, it has no clear reason or benefit.

only PLSan adopting this pattern (unlike LSan / ASan) without any benefit doesn't help getting PLSan merged into mainline LLVM.

Let's get back to functions and variables like other sanitizers :) (visitor pattern is still useful for readability, but not singleton)