### PR TITLE
Fix: Add -fno-omit-frame-pointer flag when build PLSan runtime library

### DIFF
--- a/compiler-rt/lib/plsan/CMakeLists.txt
+++ b/compiler-rt/lib/plsan/CMakeLists.txt
@@ -28,7 +28,8 @@ set(PLSAN_LINK_LIBS
     ${SANITIZER_COMMON_LINK_LIBS}
     ${COMPILER_RT_CXX_LINK_LIBS})
 set(PLSAN_CFLAGS
-    ${SANITIZER_COMMON_CFLAGS})
+    ${SANITIZER_COMMON_CFLAGS}
+    -fno-omit-frame-pointer)
 append_rtti_flag(OFF PLSAN_CFLAGS)
 
 # Allow the PLSAN runtime to reference LLVM headers.


### PR DESCRIPTION
#95 

One of Clang optimization is omitting frame pointer. That's why PLSan cannot print last reference stack trace.

We can fix it with adding -fno-omit-frame-pointer flag when compile PLSan compiler-rt code.