### PR TITLE
compiler-rt: Do not record same leak multiple times

### DIFF
--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -995,6 +995,10 @@ void setLeakedLoc(u32 alloc_stack_trace_id) {
   BufferedStackTrace stack;
   stack.Unwind(StackTrace::GetCurrentPc(), GET_CURRENT_FRAME(), nullptr, true);
   u32 stack_trace_id = StackDepotPut(stack);
+  for (uptr j = 0; j != PreciseLeakedLoc[i].Size(); j++) {
+    if (PreciseLeakedLoc[i][j] == stack_trace_id)
+      return;
+  }
   PreciseLeakedLoc[i].PushBack(stack_trace_id);
 }
 


### PR DESCRIPTION
The current implementation pushes new entry even if there is already existing the same entry. If there's already a leak with same alloc and lost stack trace, do not add new entry.