### PR TITLE
96 optimization   plsan free local variable calls internalalloc that makes plsan slow down

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -30,46 +30,28 @@ extern "C" void __plsan_store(void **lhs, void *rhs) {
   __plsan::reference_count(lhs, rhs);
 }
 
-extern "C" LazyCheckInfo *__plsan_free_local_variable(void **arr_start_addr,
-                                                      uptr size, void *ret_addr,
-                                                      bool is_return,
-                                                      bool is_allocated) {
+extern "C" void __plsan_free_local_variable(void **arr_start_addr, uptr size,
+                                            void *ret_addr, bool is_return,
+                                            bool is_allocated) {
 
   if (!is_allocated)
-    return nullptr;
+    return;
 
-  __sanitizer::Vector<void *> *ref_count_zero_addrs =
-      __plsan::free_local_variable(arr_start_addr, size, ret_addr, is_return);
-
-  // This return will be changed. It have to contain stack trace data.
-  // __builtin_return_address(0) will return program counter
-  LazyCheckInfo *lazy_check_info =
-      (LazyCheckInfo *)__sanitizer::InternalAlloc(sizeof(LazyCheckInfo));
-  CHECK(lazy_check_info);
-  lazy_check_info->RefCountZeroAddrs = ref_count_zero_addrs;
-  if (is_return) {
-    __sanitizer::InternalFree(lazy_check_info);
-    return nullptr;
-  } else {
-    return lazy_check_info;
-  }
+  __plsan::free_local_variable(arr_start_addr, size, ret_addr, is_return);
 }
 
-extern "C" void __plsan_lazy_check(LazyCheckInfo *lazy_check_info,
-                                   void *ret_addr) {
+extern "C" void __plsan_lazy_check(void *ret_addr) {
   __sanitizer::Vector<void *> *lazy_check_addr_list =
-      lazy_check_info->RefCountZeroAddrs;
+      __plsan::local_var_ref_count_zero_list;
 
-  for (int i = 0; i < lazy_check_addr_list->Size(); i++) {
+  for (int i = lazy_check_addr_list->Size() - 1; i >= 0; i--) {
     if ((*lazy_check_addr_list)[i] != ret_addr) {
       __plsan::Metadata *metadata =
           __plsan::GetMetadata((*lazy_check_addr_list)[i]);
       __lsan::setLeakedLoc(metadata->GetAllocTraceId());
+      lazy_check_addr_list->PopBack();
     }
   }
-
-  __sanitizer::InternalFree(lazy_check_addr_list);
-  __sanitizer::InternalFree(lazy_check_info);
 }
 
 extern "C" void __plsan_check_returned_or_stored_value(void *ret_ptr_addr,
@@ -111,8 +93,8 @@ void reference_count(void **lhs, void *rhs) {
 
 // addr: address of the variable
 // size: size of a variable in bytes
-__sanitizer::Vector<void *> *
-free_local_variable(void **addr, uptr size, void *ret_addr, bool is_return) {
+void free_local_variable(void **addr, uptr size, void *ret_addr,
+                         bool is_return) {
   // free_local_variable() method is called just before return instruction
   // or some method that pops(restore) stack.
   // 1. If free_local_variable() is called just before return instruction,
@@ -124,14 +106,6 @@ free_local_variable(void **addr, uptr size, void *ret_addr, bool is_return) {
   //    count. We do not check memory leak (lazy check). -> There is some cases
   //    that return restored stack value.
 
-  __sanitizer::Vector<void *> *ref_count_zero_addrs = nullptr;
-  if (is_return == false) {
-    void *mem = (__sanitizer::Vector<void *> *)__sanitizer::InternalAlloc(
-        sizeof(__sanitizer::Vector<void *>));
-    CHECK(mem);
-    ref_count_zero_addrs = new (mem) __sanitizer::Vector<void *>();
-  }
-
   void **pp = addr;
   while (pp + 1 <= addr + size / (sizeof(void *))) {
     void *ptr = *pp;
@@ -140,17 +114,11 @@ free_local_variable(void **addr, uptr size, void *ret_addr, bool is_return) {
     if (is_return == false) {
       RefCountAnalysis analysis_result = leak_analysis(metadata);
       if (analysis_result.exceptTy == RefCountZero)
-        ref_count_zero_addrs->PushBack(ptr);
+        local_var_ref_count_zero_list->PushBack(ptr);
     } else if (!IsSameObject(metadata, ptr, ret_addr)) {
       check_memory_leak(metadata);
     }
     pp++;
-  }
-
-  if (is_return == false) {
-    return ref_count_zero_addrs;
-  } else {
-    return nullptr;
   }
 }
 

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -13,6 +13,8 @@
 #include "sanitizer_common/sanitizer_stacktrace.h"
 namespace __plsan {
 
+static thread_local __sanitizer::Vector<void *> *local_var_ref_count_zero_list;
+
 enum AddrType { NonDynAlloc, DynAlloc };
 enum ExceptionType { None, RefCountZero };
 
@@ -65,6 +67,8 @@ void __plsan_init();
 void __plsan_check_memory_leak(void *addr);
 void InitializeInterceptors();
 void InstallAtExitCheckLeaks();
+void InitializeLocalVariableTLS();
+void DeleteLocalVariableTLS();
 
 } // namespace __plsan
 

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -25,8 +25,8 @@ struct RefCountAnalysis {
 };
 
 void reference_count(void **lhs, void *rhs);
-__sanitizer::Vector<void *> *
-free_local_variable(void **arr_addr, uptr size, void *ret_addr, bool is_return);
+void free_local_variable(void **arr_addr, uptr size, void *ret_addr,
+                         bool is_return);
 void check_returned_or_stored_value(void *ret_ptr_addr, void *compare_ptr_addr);
 void check_memory_leak(Metadata *metadata);
 void check_memory_leak(RefCountAnalysis analysis_result);

--- a/compiler-rt/lib/plsan/plsan_interceptors.cpp
+++ b/compiler-rt/lib/plsan/plsan_interceptors.cpp
@@ -44,6 +44,7 @@ static void *ThreadStartFunc(void *arg) {
   SetSigProcMask(&reinterpret_cast<ThreadStartArg *>(arg)->starting_sigset_,
                  nullptr);
   InternalFree(arg);
+  InitializeLocalVariableTLS();
   auto self = GetThreadSelf();
   auto args = GetThreadArgRetval().GetArgs(self);
   void *retval = (*args.routine)(args.arg_retval);
@@ -98,6 +99,7 @@ INTERCEPTOR(int, pthread_detach, void *thread) {
 
 INTERCEPTOR(int, pthread_exit, void *retval) {
   GetThreadArgRetval().Finish(GetThreadSelf(), retval);
+  DeleteLocalVariableTLS();
   return REAL(pthread_exit)(retval);
 }
 

--- a/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PreciseLeakSanitizer.h
@@ -91,6 +91,8 @@ public:
   void setCurrentFunctionEntryBlock(BasicBlock &BB);
   std::vector<MemIntrinsic *> getIntrinToInstrument();
 
+  bool isVLAExist;
+
 private:
   PreciseLeakSanitizer &Plsan;
   std::stack<std::vector<VarAddrSizeInfo>> LocalVarListStack;

--- a/scripts/test-plsan.sh
+++ b/scripts/test-plsan.sh
@@ -53,7 +53,7 @@ for test_case in $test_cases; do
 
   compile_options="-fsanitize=precise-leak"
   compile_options+=" -g -Wno-everything"
-  link_options="-lstdc++"
+  link_options=""
   # setting up compile options.
   if [ "$file_extension" == "cpp" ]; then
     compiler=build/bin/clang++


### PR DESCRIPTION
#96 

__plsan_free_local_variable calls InternalAlloc function per pointer variable in function.
InternalAlloc is dynamic allocation and too many InternalAlloc called when function return. It affects to PLSan slow down.

This pr resolve this problem with allocating one vector per thread to store all address that need to be stored in __plsan_free_local_variable. This method reduce InternalAlloc to just one time per thread.

And, there are memory leak that lazy_check didn't free all InternalAlloc memory block when llvm.stacksave and llvm.stackrestore are in another basic block. The method described above can fix this problem also.