### PR TITLE
compiler-rt: Deallocate memory in Deallocate() function

### DIFF
--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -221,6 +221,7 @@ static void Deallocate(void *p) {
 
   m->SetUnallocated();
   RegisterDeallocation(p);
+  allocator.Deallocate(GetAllocatorCache(), p);
 }
 
 static void *ReportAllocationSizeTooBig(uptr size, const StackTrace *stack) {


### PR DESCRIPTION
the Deallocate() function set the object state to unallocated, but it did not free to the primary allocator.
let's free it.

On my machine with 64GiB ram, it was able to run a full SPEC CPU2017 benchmark (intrate)
(except for the Fortran one).