### PR TITLE
(Bugfix) commpiler-rt: Do not check memory leak for freed objects

### DIFF
--- a/compiler-rt/lib/plsan/plsan.cpp
+++ b/compiler-rt/lib/plsan/plsan.cpp
@@ -63,7 +63,13 @@ extern "C" void __plsan_free_local_variable(void **addr, uptr size,
   void **pp = addr;
   while (pp + 1 <= addr + size / (sizeof(void *))) {
     void *ptr = *pp;
+
     __plsan::Metadata *metadata = __plsan::GetMetadata(ptr);
+    if (!metadata || !__plsan::IsAllocated(metadata)) {
+      pp++;
+      continue;
+    }
+
     __plsan::DecRefCount(metadata);
     if (is_return == false) {
       if (__plsan::GetRefCount(metadata) == 0)

--- a/compiler-rt/lib/plsan/plsan.h
+++ b/compiler-rt/lib/plsan/plsan.h
@@ -36,6 +36,7 @@ bool IsSameObject(Metadata *metadata, const void *p, const void *q);
 void IncRefCount(Metadata *metadata);
 void DecRefCount(Metadata *metadata);
 u8 GetRefCount(Metadata *metadata);
+bool IsAllocated(Metadata *metadata);
 u32 GetAllocTraceID(Metadata *metadata);
 
 void *plsan_malloc(uptr size, StackTrace *stack);

--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -80,6 +80,8 @@ bool IsSameObject(Metadata *metadata, const void *x, const void *y) {
 
 u8 GetRefCount(Metadata *metadata) { return metadata->GetRefCount(); }
 
+bool IsAllocated(Metadata *metadata) { return metadata->IsAllocated(); }
+
 u32 GetAllocTraceID(Metadata *metadata) { return metadata->GetAllocTraceId(); }
 
 inline void Metadata::SetAllocated(u32 stack, u64 size) {


### PR DESCRIPTION
Currently __plsan_free_local_variable() checks memory leaks for already-freed objects, and this always produces false positives. Just skip when encountered a freed object.