### PR TITLE
compiler-rt: Optimize IsSameObject()

### DIFF
--- a/compiler-rt/lib/plsan/plsan_allocator.cpp
+++ b/compiler-rt/lib/plsan/plsan_allocator.cpp
@@ -60,22 +60,7 @@ bool IsSameObject(Metadata *metadata, const void *x, const void *y) {
   if (!metadata || !y)
     return false;
 
-  if (x == y)
-    return true;
-
-  uptr size = metadata->GetRequestedSize();
-  if (size <= (1 << 15)) {
-    // size is always power of two if allocated from the primary
-    uptr a = reinterpret_cast<uptr>(x) & ~(size - 1);
-    uptr b = reinterpret_cast<uptr>(y) & ~(size - 1);
-    return a == b;
-  }
-
-  void *begin = allocator.GetBlockBegin(x);
-  if (!begin)
-    return false;
-
-  return begin <= y && (uptr)y < (uptr)begin + metadata->GetRequestedSize();
+  return (GetMetadata(y) == x);
 }
 
 u8 GetRefCount(Metadata *metadata) { return metadata->GetRefCount(); }


### PR DESCRIPTION
Now that we use multi-level shadow scheme, IsSameObject() doesn't need to call GetBlockBegin() which is dozens of times slower. Just check if the two metadata from the pointers are the same.

This improves the slowdowns in SPEC CPU2017 502.gcc_r from 350x to 7x.